### PR TITLE
Use Account2 for the WebAuthn account tests

### DIFF
--- a/testsuite/integration-arquillian/tests/other/webauthn/src/test/java/org/keycloak/testsuite/webauthn/account/AbstractWebAuthnAccountTest.java
+++ b/testsuite/integration-arquillian/tests/other/webauthn/src/test/java/org/keycloak/testsuite/webauthn/account/AbstractWebAuthnAccountTest.java
@@ -34,6 +34,7 @@ import org.keycloak.representations.idm.RealmRepresentation;
 import org.keycloak.representations.idm.RequiredActionProviderSimpleRepresentation;
 import org.keycloak.testsuite.AbstractAuthTest;
 import org.keycloak.testsuite.arquillian.annotation.EnableFeature;
+import org.keycloak.testsuite.arquillian.annotation.DisableFeature;
 import org.keycloak.testsuite.page.AbstractPatternFlyAlert;
 import org.keycloak.testsuite.ui.account2.page.SigningInPage;
 import org.keycloak.testsuite.ui.account2.page.utils.SigningInPageUtils;
@@ -56,6 +57,9 @@ import static org.keycloak.models.AuthenticationExecutionModel.Requirement.REQUI
 import static org.keycloak.testsuite.util.BrowserDriverUtil.isDriverFirefox;
 import static org.keycloak.testsuite.util.WaitUtils.waitForPageToLoad;
 
+// Enable ACCOUNT3 feature once https://github.com/keycloak/keycloak/issues/26080 is resolved
+@EnableFeature(value = Profile.Feature.ACCOUNT2, skipRestart = true)
+@DisableFeature(value = Profile.Feature.ACCOUNT3, skipRestart = true)
 public abstract class AbstractWebAuthnAccountTest extends AbstractAuthTest implements UseVirtualAuthenticators {
 
     @Page


### PR DESCRIPTION
Once the https://github.com/keycloak/keycloak/issues/26080 is resolved, the feature can be enabled for the WebAuthn tests. As we need to verify WebAuthn functionality, the version of the supportive account console should be negligible. 

@jonkoops WDYT?