### PR TITLE
Pass auth.server.host system porp to quarkus boot

### DIFF
--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/arquillian/containers/AbstractQuarkusDeployableContainer.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/arquillian/containers/AbstractQuarkusDeployableContainer.java
@@ -191,6 +191,10 @@ public abstract class AbstractQuarkusDeployableContainer implements DeployableCo
             commands.add("--log-level=" + System.getProperty("auth.server.quarkus.log-level"));
         }
 
+        if (System.getProperty("auth.server.host") != null) {
+            commands.add("-Dauth.server.host=" + System.getProperty("auth.server.host"));
+        }
+
         commands.addAll(getAdditionalBuildArgs());
 
         commands = configureArgs(commands);


### PR DESCRIPTION
The failing test `testSilentCheckSsoWithFallbackDisabled` is just reading the server address from the system prop `auth.server.host` [here](https://github.com/keycloak/keycloak/blob/26.0.5/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/rest/resource/TestJavascriptResource.java#L76). When the server is using quarkus (`-Pauth-server-quarkus`) the external jvm process ddidn't have the system prop and it defaults to `localhost`, triggering the error. Just passing the system prop to be used by the external quarkus process.
